### PR TITLE
Correct description of GET users status field

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -57,7 +57,7 @@ paths:
               - active
               - deactivated
               - all
-          description: 'The status of the users you would like returned by this endpoint. If you do not specify a status, you will get all users.'
+          description: 'The status of the users you would like returned by this endpoint. If you do not specify a status, you will get active users only.'
         - in: query
           name: created_at
           schema:


### PR DESCRIPTION
Description of this field does not match the actual behavior; default is to return active users.